### PR TITLE
PLATUI-3321: update to scala 3 and play 3

### DIFF
--- a/src/main/g8/.scalafmt.conf
+++ b/src/main/g8/.scalafmt.conf
@@ -18,6 +18,6 @@ rewrite.redundantBraces.maxBreaks = 100
 rewrite.imports.sort = ascii
 newlines.sometimesBeforeColonInMethodReturnType = true
 newlines.penalizeSingleSelectMultiArgList = false
-runner.dialect = scala213
+runner.dialect = scala3
 importSelectors = singleLine
 project.git = true

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -2,7 +2,7 @@ lazy val root = (project in file("."))
   .settings(
     name := "$name$",
     version := "0.1.0",
-    scalaVersion := "2.13.13",
+    scalaVersion := "3.3.3",
     libraryDependencies ++= Dependencies.test,
     (Compile / compile) := ((Compile / compile) dependsOn (Compile / scalafmtSbtCheck, Compile / scalafmtCheckAll)).value
   )

--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt.*
 object Dependencies {
 
   val test: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc" %% "api-test-runner" % "0.5.0" % Test
+    "uk.gov.hmrc" %% "api-test-runner" % "0.7.0" % Test
   )
 
 }

--- a/src/main/g8/src/test/scala/uk/gov/hmrc/api/client/HttpClient.scala
+++ b/src/main/g8/src/test/scala/uk/gov/hmrc/api/client/HttpClient.scala
@@ -16,9 +16,9 @@
 
 package uk.gov.hmrc.api.client
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import play.api.libs.ws.DefaultBodyWritables._
-import play.api.libs.ws.{DefaultWSProxyServer, StandaloneWSRequest}
+import play.api.libs.ws.{DefaultWSProxyServer, StandaloneWSRequest, StandaloneWSResponse}
 import play.api.libs.ws.ahc.StandaloneAhcWSClient
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -39,17 +39,17 @@ trait HttpClient {
       standAloneWsRequest
     }
 
-  def get(url: String, headers: (String, String)*): Future[StandaloneWSRequest#Self#Response] =
+  def get(url: String, headers: (String, String)*): Future[StandaloneWSResponse] =
     standAloneWsRequestWithProxyIfConfigSet(wsClient.url(url))
       .withHttpHeaders(headers: _*)
       .get()
 
-  def post(url: String, bodyAsJson: String, headers: (String, String)*): Future[StandaloneWSRequest#Self#Response] =
+  def post(url: String, bodyAsJson: String, headers: (String, String)*): Future[StandaloneWSResponse] =
     standAloneWsRequestWithProxyIfConfigSet(wsClient.url(url))
       .withHttpHeaders(headers: _*)
       .post(bodyAsJson)
 
-  def delete(url: String, headers: (String, String)*): Future[StandaloneWSRequest#Self#Response] =
+  def delete(url: String, headers: (String, String)*): Future[StandaloneWSResponse] =
     standAloneWsRequestWithProxyIfConfigSet(wsClient.url(url))
       .withHttpHeaders(headers: _*)
       .delete()


### PR DESCRIPTION
I tried this out locally by creating a repo from the template, adding the extra bits needed by sbt-auto-build, and running all scalafmt, Test/scalafmt and scalafmtSbt to make sure nothing changed in formatting rules going to scala 3 all worked as expected

The changes to return types is needed because returning a path-dependent type from within a trait doesn't work in scala 3

